### PR TITLE
fix(locations): update name retrieval method to return static value

### DIFF
--- a/apps/website/src/app/domains/locations/locations.component.ts
+++ b/apps/website/src/app/domains/locations/locations.component.ts
@@ -28,6 +28,6 @@ export default class LocationsComponent implements OnInit {
   }
 
   get name() {
-    return this.locations.map(location => location.name).join(', ');
+    return 'name';
   }
 }

--- a/apps/website/src/app/domains/products/components/product/product.component.ts
+++ b/apps/website/src/app/domains/products/components/product/product.component.ts
@@ -15,6 +15,10 @@ export class ProductComponent {
 
   readonly addToCart = output<Product>();
 
+  ngOnInit() {
+
+  }
+
   addToCartHandler() {
     this.addToCart.emit(this.product());
   }


### PR DESCRIPTION
This pull request includes minor changes to two components in the `apps/website` directory. The changes simplify the `LocationsComponent` and add an empty `ngOnInit` lifecycle hook to the `ProductComponent`.

Changes to `LocationsComponent`:

* Updated the `name` getter to return a static string `'name'` instead of dynamically generating a comma-separated list of location names. (`[apps/website/src/app/domains/locations/locations.component.tsL31-R31](diffhunk://#diff-b8ee5827881ceef9cd7032a23d7c0126cc7973979d56ed5fcef49193a7dcd313L31-R31)`)

Changes to `ProductComponent`:

* Added an empty `ngOnInit` lifecycle hook to the class, preparing it for future initialization logic. (`[apps/website/src/app/domains/products/components/product/product.component.tsR18-R21](diffhunk://#diff-7f656484f55c55ab8d8ee523c63c459f2a00660c82bc33c8c297957968191610R18-R21)`)